### PR TITLE
fix: Update routes import to use named export instead of default export

### DIFF
--- a/src/routes/RouteProvider.tsx
+++ b/src/routes/RouteProvider.tsx
@@ -1,7 +1,7 @@
 
 import { Suspense, lazy } from "react";
 import { Routes, Route, useNavigate } from "react-router-dom";
-import routes from "./routes";
+import { routes } from "./routes";
 import { Button } from "@/components/ui/button";
 import { RefreshCw, Home } from "lucide-react";
 


### PR DESCRIPTION
- Fix build error in RouteProvider.tsx
- Change from 'import routes' to 'import { routes }'
- Resolves Netlify build failure